### PR TITLE
Fixed responsivity of partner logos

### DIFF
--- a/app/views/index.pug
+++ b/app/views/index.pug
@@ -107,18 +107,18 @@ block content
         .row
           h3 Partneři
           a(href="https://google.com")
-            img(src='/images/logos/logo-google.svg').responsive-img
+            img(src='/images/logos/logo-google.svg', alt='Google').responsive-img
       .container
         .row
           .col.s12.m4.center-align.partner-logo-img
             a(href="https://auth0.com/?utm_source=oss&utm_medium=gp&utm_campaign=oss")
-              img(src='//cdn.auth0.com/oss/badges/a0-badge-light.png', alt='JWT Auth for open source projects', height='70px')
+              img(src='//cdn.auth0.com/oss/badges/a0-badge-light.png', alt='JWT Auth for open source projects').responsive-img
           .col.s12.m4.center-align.partner-logo-img
             a(href="https://dotekomanie.cz")
-              img(src='/images/logos/logo-dotekomanie.png', height='70px')
+              img(src='/images/logos/logo-dotekomanie.png', alt='Dotekománie.cz').responsive-img
           .col.s12.m4.center-align.partner-logo-img
             a(href="http://pracovnapraha.cz/")
-              img(src='/images/logos/logo-zenysro.png', height='70px')
+              img(src='/images/logos/logo-zenysro.png', alt='Ženy s.r.o.').responsive-img
       .container.center
         .row
           a.waves-effect.waves-light.btn.btn-large(href='mailto:filip@gug.cz?subject=Partnerství s GUG.cz')


### PR DESCRIPTION
Všiml jsem si u menších zařízení, že se loga překrývají - nepoužil jsem `.responsive-img`, které jsem na lokálním spuštění a testování z nějakého důvodu nepotřeboval.

`.responsive-img` totiž hodně zmenšovalo dlouhá loga - např. Dotekománie.cz